### PR TITLE
exit queue exits modal

### DIFF
--- a/src/app/queue-page/queue-page.component.html
+++ b/src/app/queue-page/queue-page.component.html
@@ -50,7 +50,7 @@
 
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-primary" routerLink="/gamelist" (click)="exitQueue()">Yes</button>
+          <button type="button" class="btn btn-primary" data-bs-dismiss="modal" routerLink="/gamelist" (click)="exitQueue()">Yes</button>
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">No</button>
         </div>
       </div>


### PR DESCRIPTION
The reason the modal wasn't going away was just because the "yes" button in exiting the queue didn't have the data-bs-dismiss thing in its html. That's all I needed to add.